### PR TITLE
修正一处链接错误

### DIFF
--- a/draft/issue14/issue-14-0-johnnywjy.md
+++ b/draft/issue14/issue-14-0-johnnywjy.md
@@ -23,4 +23,4 @@ Chris，Daniel，与 Florian
 [2]: http://objccn.io/issue-14-2/
 [3]: http://objccn.io/issue-14-3/
 [4]: http://objccn.io/issue-14-4/
-[5]: http://objccn.io/issue-15-5/
+[5]: http://objccn.io/issue-14-5/


### PR DESCRIPTION
《给 UIKit 开发者的 AppKit 指南》应当指向14-5，但是错误地指向了15-5。
